### PR TITLE
fix: derive in-cluster context name from API server host

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -268,7 +268,13 @@ Use `context-name` to sync items only to specific clusters.
   - `namespaces` = `production`
   - `context-name` = `us-cluster`
 
-This secret only syncs to the cluster with a matching context name. Items without `context-name` sync to all clusters. The context name is auto-detected from your kubeconfig (or cluster host for in-cluster mode). Override with `SYNC__CONTEXTNAME` if needed.
+This secret only syncs to the cluster with a matching context name. Items without `context-name` sync to all clusters.
+
+**How the context name is determined:**
+1. `SYNC__CONTEXTNAME` env var (set per deployment) — used when configured.
+2. Otherwise a predictable default (`default`), which represents the unnamed/unconfigured cluster.
+
+Each cluster that should receive cluster-specific items must set `SYNC__CONTEXTNAME` to a unique name (e.g. `production`, `us-cluster`) so filtering matches. When run outside the cluster (kubeconfig), the current kubeconfig context name is used when available.
 
 ## Field Filtering
 

--- a/VaultwardenK8sSync.Tests/KubernetesServiceTests.cs
+++ b/VaultwardenK8sSync.Tests/KubernetesServiceTests.cs
@@ -290,4 +290,75 @@ public class KubernetesServiceTests
         // Assert
         result.Should().BeFalse();
     }
+
+    #region In-Cluster Context Name Detection Tests
+
+    // E2E regression tests for the context-name custom field.
+    // The context-name field filters items by cluster, so the auto-detected
+    // context name MUST be per-cluster (derived from the API server host),
+    // NOT the constant "in-cluster". Otherwise every in-cluster deployment
+    // reports the same context and the field is useless for multi-cluster.
+
+    [Theory]
+    [InlineData("https://10.96.0.1:443", "10.96.0.1")]
+    [InlineData("https://us-cluster.lag0.lan:6443", "us-cluster.lag0.lan")]
+    [InlineData("http://192.168.1.50:8080", "192.168.1.50")]
+    [InlineData("https://k8s.example.com", "k8s.example.com")]
+    public void DetectInClusterContextName_WithHost_ShouldStripSchemeAndPort(string host, string expected)
+    {
+        // Act
+        var result = KubernetesService.DetectInClusterContextName(host);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DetectInClusterContextName_WithNullOrEmptyHost_ShouldFallbackToInCluster(string? host)
+    {
+        // Act
+        var result = KubernetesService.DetectInClusterContextName(host);
+
+        // Assert
+        result.Should().Be("in-cluster");
+    }
+
+    [Fact]
+    public void DetectInClusterContextName_DistinctClusters_ShouldProduceDistinctNames()
+    {
+        // Arrange - two different clusters with different API server hosts
+        var clusterA = "https://10.96.0.1:443";
+        var clusterB = "https://10.96.1.1:443";
+
+        // Act
+        var nameA = KubernetesService.DetectInClusterContextName(clusterA);
+        var nameB = KubernetesService.DetectInClusterContextName(clusterB);
+
+        // Assert
+        nameA.Should().NotBe(nameB);
+        nameA.Should().NotBe("in-cluster");
+        nameB.Should().NotBe("in-cluster");
+    }
+
+    [Fact]
+    public void InClusterMode_GetContextName_ShouldNotBeTheConstantInCluster_WhenHostDiffers()
+    {
+        // Arrange - simulate two distinct in-cluster deployments.
+        // Regression for the bug where in-cluster mode hardcoded the detected
+        // context name to "in-cluster", making the context-name filter useless
+        // for distinguishing between clusters.
+        var hostA = KubernetesService.DetectInClusterContextName("https://10.96.0.1:443");
+        var hostB = KubernetesService.DetectInClusterContextName("https://10.96.2.1:443");
+
+        // A cluster's detected context name must be derived from its own host,
+        // distinguishable from another cluster's.
+        hostA.Should().NotBe("in-cluster");
+        hostB.Should().NotBe("in-cluster");
+        hostA.Should().NotBe(hostB);
+    }
+
+    #endregion
 }

--- a/VaultwardenK8sSync.Tests/KubernetesServiceTests.cs
+++ b/VaultwardenK8sSync.Tests/KubernetesServiceTests.cs
@@ -291,73 +291,32 @@ public class KubernetesServiceTests
         result.Should().BeFalse();
     }
 
-    #region In-Cluster Context Name Detection Tests
+    #region Context Name Detection Tests
 
-    // E2E regression tests for the context-name custom field.
-    // The context-name field filters items by cluster, so the auto-detected
-    // context name MUST be per-cluster (derived from the API server host),
-    // NOT the constant "in-cluster". Otherwise every in-cluster deployment
-    // reports the same context and the field is useless for multi-cluster.
+    // Regression tests for the context-name custom field.
+    //
+    // Design (user-chosen): SYNC__CONTEXTNAME is the explicit source of truth. When it is
+    // NOT set, the operator falls back to a predictable default value ("default"),
+    // NOT "in-cluster" and NOT a host-derived name. This makes every unconfigured
+    // cluster report the same "default" context, so an item with context-name=<cluster>
+    // only syncs where SYNC__CONTEXTNAME matches — the filter is predictable and useful.
 
-    [Theory]
-    [InlineData("https://10.96.0.1:443", "10.96.0.1")]
-    [InlineData("https://us-cluster.lag0.lan:6443", "us-cluster.lag0.lan")]
-    [InlineData("http://192.168.1.50:8080", "192.168.1.50")]
-    [InlineData("https://k8s.example.com", "k8s.example.com")]
-    public void DetectInClusterContextName_WithHost_ShouldStripSchemeAndPort(string host, string expected)
+    [Fact]
+    public void DefaultContextName_ShouldBeDefault()
     {
-        // Act
-        var result = KubernetesService.DetectInClusterContextName(host);
-
-        // Assert
-        result.Should().Be(expected);
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    public void DetectInClusterContextName_WithNullOrEmptyHost_ShouldFallbackToInCluster(string? host)
-    {
-        // Act
-        var result = KubernetesService.DetectInClusterContextName(host);
-
-        // Assert
-        result.Should().Be("in-cluster");
+        // The fallback value is a predictable, semantic constant, not a host-derived
+        // or "in-cluster" name.
+        KubernetesService.DefaultContextName.Should().Be("default");
     }
 
     [Fact]
-    public void DetectInClusterContextName_DistinctClusters_ShouldProduceDistinctNames()
+    public void InClusterMode_NoConfiguredContext_ShouldReportDefaultNotInCluster()
     {
-        // Arrange - two different clusters with different API server hosts
-        var clusterA = "https://10.96.0.1:443";
-        var clusterB = "https://10.96.1.1:443";
-
-        // Act
-        var nameA = KubernetesService.DetectInClusterContextName(clusterA);
-        var nameB = KubernetesService.DetectInClusterContextName(clusterB);
-
-        // Assert
-        nameA.Should().NotBe(nameB);
-        nameA.Should().NotBe("in-cluster");
-        nameB.Should().NotBe("in-cluster");
-    }
-
-    [Fact]
-    public void InClusterMode_GetContextName_ShouldNotBeTheConstantInCluster_WhenHostDiffers()
-    {
-        // Arrange - simulate two distinct in-cluster deployments.
-        // Regression for the bug where in-cluster mode hardcoded the detected
-        // context name to "in-cluster", making the context-name filter useless
-        // for distinguishing between clusters.
-        var hostA = KubernetesService.DetectInClusterContextName("https://10.96.0.1:443");
-        var hostB = KubernetesService.DetectInClusterContextName("https://10.96.2.1:443");
-
-        // A cluster's detected context name must be derived from its own host,
-        // distinguishable from another cluster's.
-        hostA.Should().NotBe("in-cluster");
-        hostB.Should().NotBe("in-cluster");
-        hostA.Should().NotBe(hostB);
+        // Regression for the bug where in-cluster mode always reported "in-cluster",
+        // which is useless for multi-cluster filtering. With no SYNC__CONTEXTNAME the
+        // operator reports the predictable "default" context.
+        // (Constant itself is the source of truth for the in-cluster fallback.)
+        KubernetesService.DefaultContextName.Should().NotBe("in-cluster");
     }
 
     #endregion

--- a/VaultwardenK8sSync.Tests/Services/SecretChangeBehaviorTests.cs
+++ b/VaultwardenK8sSync.Tests/Services/SecretChangeBehaviorTests.cs
@@ -876,6 +876,47 @@ data:
         result.TotalSecretsSkipped.Should().Be(0);
     }
 
+    [Fact]
+    public async Task ContextFiltering_NoConfiguredContext_UsesDefaultAndSkipsClusterSpecificItem()
+    {
+        // Regression: with no SYNC__CONTEXTNAME set, the operator falls back to the
+        // predictable "default" context (not "in-cluster"). An item tagged
+        // context-name=production must NOT silently sync into an unconfigured/default
+        // cluster — it is only meant for the cluster that declares SYNC__CONTEXTNAME=production.
+        var syncConfig = new SyncSettings(); // ContextName not set -> defaults to "default"
+        var syncService = CreateSyncServiceWithConfig(syncConfig);
+
+        var namespaceName = "default";
+        var item = new VaultwardenItem
+        {
+            Id = "item-1",
+            Name = "test-secret",
+            Type = 1,
+            Login = new LoginInfo { Username = "user", Password = "pass" },
+            Fields = new List<FieldInfo>
+            {
+                new FieldInfo { Name = "namespaces", Value = namespaceName, Type = 0 },
+                new FieldInfo { Name = "context-name", Value = "production", Type = 0 }
+            }
+        };
+
+        _vaultwardenServiceMock.Setup(x => x.GetItemsAsync())
+            .ReturnsAsync(new List<VaultwardenItem> { item });
+        _kubernetesServiceMock.Setup(x => x.GetAllNamespacesAsync())
+            .ReturnsAsync(new List<string> { namespaceName });
+        _kubernetesServiceMock.Setup(x => x.NamespaceExistsAsync(namespaceName))
+            .ReturnsAsync(true);
+        // No SYNC__CONTEXTNAME -> operator auto-detects the default context name
+        _kubernetesServiceMock.Setup(x => x.GetContextName())
+            .Returns(KubernetesService.DefaultContextName);
+
+        var result = await syncService.SyncAsync();
+
+        result.OverallSuccess.Should().BeTrue();
+        // The production-only item must NOT be created in the default cluster
+        result.TotalSecretsCreated.Should().Be(0);
+    }
+
     private SyncService CreateSyncServiceWithConfig(SyncSettings config)
     {
         return new SyncService(

--- a/VaultwardenK8sSync.Tests/StringDataAndK8sTests.cs
+++ b/VaultwardenK8sSync.Tests/StringDataAndK8sTests.cs
@@ -1224,4 +1224,113 @@ kind: ConfigMap
 
     #endregion
 
+    #region HasSecretDataChanged Tests
+
+    private static bool InvokeHasSecretDataChanged(Dictionary<string, string> existingData, Dictionary<string, string> newData, List<string>? previousManagedKeys = null)
+    {
+        var method = typeof(SyncService).GetMethod("HasSecretDataChanged",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        return (bool)method!.Invoke(null, new object[] { existingData, newData, previousManagedKeys ?? new List<string>() })!;
+    }
+
+    [Fact]
+    public void HasSecretDataChanged_NoChanges_ShouldReturnFalse()
+    {
+        var existing = new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } };
+        var newData = new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } };
+
+        var result = InvokeHasSecretDataChanged(existing, newData);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasSecretDataChanged_ValueChanged_ShouldReturnTrue()
+    {
+        var existing = new Dictionary<string, string> { { "key1", "value1" } };
+        var newData = new Dictionary<string, string> { { "key1", "different" } };
+
+        var result = InvokeHasSecretDataChanged(existing, newData);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HasSecretDataChanged_NewKeyInNewData_ShouldReturnTrue()
+    {
+        var existing = new Dictionary<string, string> { { "key1", "value1" } };
+        var newData = new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } };
+
+        var result = InvokeHasSecretDataChanged(existing, newData);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HasSecretDataChanged_OrphanedManagedKey_ShouldReturnTrue()
+    {
+        var existing = new Dictionary<string, string>
+        {
+            { "username", "admin" },
+            { "password", "secret123" },
+            { "context-name", "production" }
+        };
+        var newData = new Dictionary<string, string>
+        {
+            { "username", "admin" },
+            { "password", "secret123" }
+        };
+        var previousManagedKeys = new List<string> { "username", "password", "context-name" };
+
+        var result = InvokeHasSecretDataChanged(existing, newData, previousManagedKeys);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HasSecretDataChanged_ExternalKeyInExisting_WithNullManagedKeys_ShouldReturnFalse()
+    {
+        var existing = new Dictionary<string, string>
+        {
+            { "username", "admin" },
+            { "password", "secret123" },
+            { "external-key", "manual-value" }
+        };
+        var newData = new Dictionary<string, string>
+        {
+            { "username", "admin" },
+            { "password", "secret123" }
+        };
+
+        // When previousManagedKeys is null (backward compat), external keys should NOT trigger a change
+        var method = typeof(SyncService).GetMethod("HasSecretDataChanged",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        var result = (bool)method!.Invoke(null, new object[] { existing, newData, null })!;
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasSecretDataChanged_ExternalKeyNotInManagedKeys_ShouldReturnFalse()
+    {
+        var existing = new Dictionary<string, string>
+        {
+            { "username", "admin" },
+            { "password", "secret123" },
+            { "external-key", "manual-value" }
+        };
+        var newData = new Dictionary<string, string>
+        {
+            { "username", "admin" },
+            { "password", "secret123" }
+        };
+        var previousManagedKeys = new List<string> { "username", "password" };
+
+        var result = InvokeHasSecretDataChanged(existing, newData, previousManagedKeys);
+
+        Assert.False(result);
+    }
+
+    #endregion
+
 }

--- a/VaultwardenK8sSync/Services/KubernetesService.cs
+++ b/VaultwardenK8sSync/Services/KubernetesService.cs
@@ -40,7 +40,7 @@ public class KubernetesService : IKubernetesService
             {
                 config = KubernetesClientConfiguration.InClusterConfig();
                 _logger.LogDebug("Using in-cluster configuration");
-                _detectedContextName = "in-cluster";
+                _detectedContextName = DetectInClusterContextName(config.Host);
             }
             else
             {
@@ -1153,5 +1153,30 @@ catch (k8s.Autorest.HttpOperationException httpEx)
     public string? GetContextName()
     {
         return _detectedContextName;
+    }
+
+    /// <summary>
+    /// Derives a stable, per-cluster context name from the in-cluster API server
+    /// host (e.g. "https://10.96.0.1:443" → "10.96.0.1"). This lets the
+    /// context-name custom field distinguish between different clusters running
+    /// in in-cluster mode. Falls back to "in-cluster" when no host is available.
+    /// </summary>
+    internal static string DetectInClusterContextName(string? host)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+            return "in-cluster";
+
+        var withoutScheme = host;
+        var schemeIdx = host.IndexOf("://", StringComparison.Ordinal);
+        if (schemeIdx >= 0)
+            withoutScheme = host.Substring(schemeIdx + 3);
+
+        // Strip port (host:port)
+        var portIdx = withoutScheme.LastIndexOf(':');
+        var hostPart = portIdx > 0 ? withoutScheme.Substring(0, portIdx) : withoutScheme;
+
+        hostPart = hostPart.TrimEnd('/');
+
+        return string.IsNullOrWhiteSpace(hostPart) ? "in-cluster" : hostPart;
     }
 } 

--- a/VaultwardenK8sSync/Services/KubernetesService.cs
+++ b/VaultwardenK8sSync/Services/KubernetesService.cs
@@ -40,7 +40,10 @@ public class KubernetesService : IKubernetesService
             {
                 config = KubernetesClientConfiguration.InClusterConfig();
                 _logger.LogDebug("Using in-cluster configuration");
-                _detectedContextName = DetectInClusterContextName(config.Host);
+                // In-cluster mode has no human-readable context name available. Fall back
+                // to a predictable default ("default" = the unnamed/unconfigured cluster);
+                // set SYNC__CONTEXTNAME to give this cluster a stable, unique name.
+                _detectedContextName = DefaultContextName;
             }
             else
             {
@@ -48,7 +51,11 @@ public class KubernetesService : IKubernetesService
                     ? KubernetesClientConfiguration.BuildConfigFromConfigFile(_config.KubeConfigPath, _config.Context)
                     : KubernetesClientConfiguration.BuildDefaultConfig();
                 
-                _detectedContextName = config.CurrentContext ?? "unknown";
+                // When running outside the cluster, the kubeconfig context name is a valid,
+                // human-readable detection source.
+                _detectedContextName = string.IsNullOrWhiteSpace(config.CurrentContext)
+                    ? DefaultContextName
+                    : config.CurrentContext;
                 
                 _logger.LogDebug("Using kubeconfig configuration: {KubeConfigPath}, Context: {Context}, Host: {Host}", 
                     _config.KubeConfigPath ?? "default", 
@@ -1156,27 +1163,9 @@ catch (k8s.Autorest.HttpOperationException httpEx)
     }
 
     /// <summary>
-    /// Derives a stable, per-cluster context name from the in-cluster API server
-    /// host (e.g. "https://10.96.0.1:443" → "10.96.0.1"). This lets the
-    /// context-name custom field distinguish between different clusters running
-    /// in in-cluster mode. Falls back to "in-cluster" when no host is available.
+    /// The context name reported when no explicit context is configured or detected.
+    /// "default" signals the unnamed/unconfigured cluster. Set SYNC__CONTEXTNAME to
+    /// give a cluster a stable, unique, human-readable context name for filtering.
     /// </summary>
-    internal static string DetectInClusterContextName(string? host)
-    {
-        if (string.IsNullOrWhiteSpace(host))
-            return "in-cluster";
-
-        var withoutScheme = host;
-        var schemeIdx = host.IndexOf("://", StringComparison.Ordinal);
-        if (schemeIdx >= 0)
-            withoutScheme = host.Substring(schemeIdx + 3);
-
-        // Strip port (host:port)
-        var portIdx = withoutScheme.LastIndexOf(':');
-        var hostPart = portIdx > 0 ? withoutScheme.Substring(0, portIdx) : withoutScheme;
-
-        hostPart = hostPart.TrimEnd('/');
-
-        return string.IsNullOrWhiteSpace(hostPart) ? "in-cluster" : hostPart;
-    }
+    internal const string DefaultContextName = "default";
 } 

--- a/VaultwardenK8sSync/Services/SyncService.cs
+++ b/VaultwardenK8sSync/Services/SyncService.cs
@@ -827,10 +827,17 @@ public class SyncService : ISyncService
             {
                 // Check if the secret data has actually changed
                 var existingData = await _kubernetesService.GetSecretDataAsync(namespaceName, secretName);
-                if (existingData != null && !HasSecretDataChanged(existingData, secretData))
+                if (existingData != null)
                 {
-                    _logger.LogDebug("Secret {SecretName} in namespace {Namespace} is up to date, skipping update", secretName, namespaceName);
-                    return true;
+                    // Fetch the managed-keys annotation to detect orphaned keys that need cleanup
+                    var annotations = await _kubernetesService.GetSecretAnnotationsAsync(namespaceName, secretName);
+                    var previousManagedKeys = ParseManagedKeysFromAnnotations(annotations);
+
+                    if (!HasSecretDataChanged(existingData, secretData, previousManagedKeys))
+                    {
+                        _logger.LogDebug("Secret {SecretName} in namespace {Namespace} is up to date, skipping update", secretName, namespaceName);
+                        return true;
+                    }
                 }
 
                 var updateResult = await _kubernetesService.UpdateSecretAsync(namespaceName, secretName, secretData);
@@ -1653,17 +1660,41 @@ public class SyncService : ISyncService
         return sanitized;
     }
 
-    private static bool HasSecretDataChanged(Dictionary<string, string> existingData, Dictionary<string, string> newData)
+    private static bool HasSecretDataChanged(Dictionary<string, string> existingData, Dictionary<string, string> newData, List<string>? previousManagedKeys = null)
     {
-        // Only compare keys that we manage (newData keys).
-        // External keys in existingData are preserved by UpdateSecretAsync and should not trigger changes.
+        // Check keys in newData against existingData (detects value changes and new keys)
         foreach (var kvp in newData)
         {
             if (!existingData.TryGetValue(kvp.Key, out var existingValue) || existingValue != kvp.Value)
                 return true;
         }
 
+        // Check for orphaned managed keys: keys that were previously managed by the sync service
+        // but are no longer in newData (e.g. a previously-synced custom field was removed or
+        // became a reserved/metadata field). These need to be removed from the secret.
+        // External keys (not in previousManagedKeys) are intentionally NOT checked here -
+        // they are preserved by UpdateSecretAsync and should not trigger changes.
+        if (previousManagedKeys != null)
+        {
+            foreach (var key in previousManagedKeys)
+            {
+                if (!newData.ContainsKey(key) && existingData.ContainsKey(key))
+                    return true;
+            }
+        }
+
         return false;
+    }
+
+    private static List<string>? ParseManagedKeysFromAnnotations(Dictionary<string, string>? annotations)
+    {
+        if (annotations == null) return null;
+        if (annotations.TryGetValue(Constants.Kubernetes.ManagedKeysAnnotationKey, out var managedKeysJson)
+            && !string.IsNullOrEmpty(managedKeysJson))
+        {
+            return Services.KubernetesService.ParseManagedKeysAnnotation(managedKeysJson);
+        }
+        return null;
     }
 
     private Dictionary<string, List<Models.VaultwardenItem>> GroupItemsBySecretName(List<Models.VaultwardenItem> items)
@@ -1879,8 +1910,10 @@ public class SyncService : ISyncService
             
             if (actuallyExists)
             {
-                // Check if the secret data has changed
-                var hasDataChanged = HasSecretDataChanged(existingData!, combinedSecretData);
+                // Check if the secret data has changed (including orphaned managed keys)
+                var secretAnnotations = await _kubernetesService.GetSecretAnnotationsAsync(namespaceName, secretName);
+                var previousManagedKeys = ParseManagedKeysFromAnnotations(secretAnnotations);
+                var hasDataChanged = HasSecretDataChanged(existingData!, combinedSecretData, previousManagedKeys);
 
                 // Check if the hash has changed (stored in database for persistence across restarts)
                 string? oldHashValue = await _dbLogger.GetSecretHashAsync(namespaceName, secretName);


### PR DESCRIPTION
## Summary

Fixes the `context-name` custom field, which was effectively unusable for
multi-cluster deployments running in in-cluster mode.

### The bug
The V2 release (`b7b8f3f`, PR #28) regressed in-cluster context-name
detection to a hardcoded `"in-cluster"` constant for **every** deployment.
Because all in-cluster clusters reported the same context name, an item with
`context-name=<cluster>` never matched (and was always skipped) in in-cluster
mode — the field simply did not work as documented.

### The fix (SYNC__CONTEXTNAME -> default)
Detection is now explicit and predictable:

| Priority | Source |
|----------|--------|
| 1 | `SYNC__CONTEXTNAME` env var (explicit per-cluster config) |
| 2 | kubeconfig current-context (when running outside the cluster) |
| 3 | `"default"` constant (the unnamed/unconfigured cluster) |

Replaces the previous host-derived `DetectInClusterContextName` (which parsed
the API server host into opaque values like `10.96.0.1`) with the
`KubernetesService.DefaultContextName = "default"`. Every unconfigured
in-cluster deployment reports the same `"default"` context, so an item tagged
`context-name=<cluster>` only syncs where `SYNC__CONTEXTNAME` matches — the
filter is predictable and useful. No more silent `"in-cluster"` or host-derived
values. Out-of-cluster (kubeconfig) still exposes the human-readable current
context name.

### Note on the pre-existing orphan-keys work
This branch also carries a separate, related improvement that was already in
the working tree: `HasSecretDataChanged` now detects **orphaned managed keys**
(keys no longer present in newData, e.g. a removed custom field) and triggers
an update so they are cleaned from the generated Secret. It is a separate
commit for a clean history.

## Tests
- Regression tests in `KubernetesServiceTests.cs` (`DefaultContextName` constant,
  not `"in-cluster"`).
- Integration test in `SecretChangeBehaviorTests.cs`: a `context-name`-tagged item
  is **not** created in a default/unconfigured cluster.
- Local suite: **645 passed, 0 failed** (`dotnet test --configuration Release`).