### PR TITLE
fix: YAML Secret in notes + namespaces field created an empty secret

### DIFF
--- a/VaultwardenK8sSync.Tests/YamlFromNamespaceLessItemsTests.cs
+++ b/VaultwardenK8sSync.Tests/YamlFromNamespaceLessItemsTests.cs
@@ -306,6 +306,71 @@ stringData:
             Times.Once);
     }
 
+    // A multi-Secret YAML in a note must NOT merge unrelated secrets. Only the Secret whose
+    // metadata.name matches the target is used; the other definitions are ignored.
+    [Fact]
+    public async Task SyncAsync_MultiSecretYamlInNotes_ShouldOnlyExtractMatchingSecret()
+    {
+        const string yamlWithTwoSecrets = @"apiVersion: v1
+kind: Secret
+metadata:
+  name: netbird-setup
+  namespace: monitoring
+type: Opaque
+stringData:
+  TARGET_KEY: target-value
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: other-secret
+  namespace: monitoring
+type: Opaque
+stringData:
+  OTHER_KEY: other-value";
+
+        var item = new VaultwardenItem
+        {
+            Id = "item-1",
+            Name = "netbird-setup",
+            Type = 2,
+            SecureNote = new SecureNoteInfo { Type = 0 },
+            Notes = yamlWithTwoSecrets,
+            Fields = new List<FieldInfo>
+            {
+                new FieldInfo { Name = "namespaces", Value = "monitoring", Type = 0 }
+            }
+        };
+
+        _vaultwardenServiceMock.Setup(x => x.GetItemsAsync())
+            .ReturnsAsync(new List<VaultwardenItem> { item });
+        _kubernetesServiceMock.Setup(x => x.NamespaceExistsAsync("monitoring")).ReturnsAsync(true);
+        _kubernetesServiceMock.Setup(x => x.GetExistingSecretNamesAsync("monitoring")).ReturnsAsync(new List<string>());
+        _kubernetesServiceMock.Setup(x => x.GetManagedSecretNamesAsync("monitoring")).ReturnsAsync(new List<string>());
+        _kubernetesServiceMock.Setup(x => x.SecretExistsAsync("monitoring", "netbird-setup")).ReturnsAsync(false);
+        _kubernetesServiceMock.Setup(x => x.GetSecretDataAsync("monitoring", "netbird-setup")).ReturnsAsync((Dictionary<string, string>?)null);
+        _kubernetesServiceMock.Setup(x => x.GetSecretAnnotationsAsync("monitoring", "netbird-setup")).ReturnsAsync((Dictionary<string, string>?)null);
+        _kubernetesServiceMock.Setup(x => x.GetSecretTypeAsync("monitoring", "netbird-setup")).ReturnsAsync((string?)null);
+        _kubernetesServiceMock.Setup(x => x.CreateSecretAsync(
+                It.IsAny<string>(), "netbird-setup", It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<string?>()))
+            .ReturnsAsync(OperationResult.Successful());
+        _kubernetesServiceMock.Setup(x => x.ApplyYamlAsync(It.IsAny<string>()))
+            .ReturnsAsync(OperationResult.Successful());
+
+        var result = await _syncService.SyncAsync();
+
+        result.OverallSuccess.Should().BeTrue();
+
+        // Only the matching secret's data is carried through; the unrelated secret's key
+        // must not bleed into the target secret.
+        _kubernetesServiceMock.Verify(x => x.CreateSecretAsync(
+            "monitoring", "netbird-setup",
+            It.Is<Dictionary<string, string>>(d => d.ContainsKey("TARGET_KEY") && !d.ContainsKey("OTHER_KEY")),
+            It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<string?>()),
+            Times.Once);
+    }
+
     [Fact]
     public async Task SyncAsync_WithNoNamespacesAndNoYaml_ShouldNotApplyAnyYaml()
     {

--- a/VaultwardenK8sSync.Tests/YamlFromNamespaceLessItemsTests.cs
+++ b/VaultwardenK8sSync.Tests/YamlFromNamespaceLessItemsTests.cs
@@ -178,6 +178,134 @@ data:
             Times.Once);
     }
 
+    // Regression: an item with Kubernetes YAML in NOTES plus a `namespaces` custom field
+    // must produce a Secret that carries the YAML's data (e.g. stringData), NOT an empty
+    // one. Prior behavior: the YAML was applied via ApplyYamlAsync() but then the normal
+    // secret path (SyncSecretAsync -> CreateSecretAsync) created/overwrote the Secret with
+    // an empty combinedSecretData, yielding a Secret with no data and managed-keys: [].
+    [Fact]
+    public async Task SyncAsync_YamlSecretInNotesWithNamespaces_ShouldCarryYamlData_NotEmpty()
+    {
+        const string yamlWithStringData = @"apiVersion: v1
+kind: Secret
+metadata:
+  name: netbird-setup
+  namespace: monitoring
+type: Opaque
+stringData:
+  NETBIRD_SETUP_KEY: supersecretvalue";
+
+        var item = new VaultwardenItem
+        {
+            Id = "item-1",
+            Name = "netbird-setup",
+            Type = 2,
+            SecureNote = new SecureNoteInfo { Type = 0 },
+            Notes = yamlWithStringData,
+            Fields = new List<FieldInfo>
+            {
+                new FieldInfo { Name = "namespaces", Value = "monitoring", Type = 0 }
+            }
+        };
+
+        _vaultwardenServiceMock.Setup(x => x.GetItemsAsync())
+            .ReturnsAsync(new List<VaultwardenItem> { item });
+        _kubernetesServiceMock.Setup(x => x.NamespaceExistsAsync("monitoring"))
+            .ReturnsAsync(true);
+        _kubernetesServiceMock.Setup(x => x.GetExistingSecretNamesAsync("monitoring"))
+            .ReturnsAsync(new List<string>());
+        _kubernetesServiceMock.Setup(x => x.GetManagedSecretNamesAsync("monitoring"))
+            .ReturnsAsync(new List<string>());
+        _kubernetesServiceMock.Setup(x => x.SecretExistsAsync("monitoring", "netbird-setup"))
+            .ReturnsAsync(false);
+        _kubernetesServiceMock.Setup(x => x.GetSecretDataAsync("monitoring", "netbird-setup"))
+            .ReturnsAsync((Dictionary<string, string>?)null);
+        _kubernetesServiceMock.Setup(x => x.GetSecretAnnotationsAsync("monitoring", "netbird-setup"))
+            .ReturnsAsync((Dictionary<string, string>?)null);
+        _kubernetesServiceMock.Setup(x => x.GetSecretTypeAsync("monitoring", "netbird-setup"))
+            .ReturnsAsync((string?)null);
+        _kubernetesServiceMock.Setup(x => x.CreateSecretAsync(
+                "monitoring", "netbird-setup", It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<string?>()))
+            .ReturnsAsync(OperationResult.Successful());
+        _kubernetesServiceMock.Setup(x => x.ApplyYamlAsync(It.IsAny<string>()))
+            .ReturnsAsync(OperationResult.Successful());
+
+        var result = await _syncService.SyncAsync();
+
+        result.OverallSuccess.Should().BeTrue();
+
+        // The Secret created by the normal path MUST NOT be empty: it should carry the
+        // value defined in the YAML's stringData. This is the regression we fixed.
+        _kubernetesServiceMock.Verify(x => x.CreateSecretAsync(
+            "monitoring", "netbird-setup",
+            It.Is<Dictionary<string, string>>(d => d.ContainsKey("NETBIRD_SETUP_KEY") && d["NETBIRD_SETUP_KEY"] == "supersecretvalue"),
+            It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<string?>()),
+            Times.Once);
+    }
+
+    // A YAML Secret with a `namespaces` custom field listing multiple namespaces must be
+    // created with the YAML's data in EACH declared namespace (not just the one hardcoded
+    // in the manifest, and never as an empty secret).
+    [Fact]
+    public async Task SyncAsync_YamlSecretInNotesWithMultipleNamespaces_ShouldCreateWithDataInEach()
+    {
+        const string yamlWithStringData = @"apiVersion: v1
+kind: Secret
+metadata:
+  name: netbird-setup
+  namespace: monitoring
+type: Opaque
+stringData:
+  NETBIRD_SETUP_KEY: supersecretvalue";
+
+        var item = new VaultwardenItem
+        {
+            Id = "item-1",
+            Name = "netbird-setup",
+            Type = 2,
+            SecureNote = new SecureNoteInfo { Type = 0 },
+            Notes = yamlWithStringData,
+            Fields = new List<FieldInfo>
+            {
+                new FieldInfo { Name = "namespaces", Value = "monitoring,other", Type = 0 }
+            }
+        };
+
+        _vaultwardenServiceMock.Setup(x => x.GetItemsAsync())
+            .ReturnsAsync(new List<VaultwardenItem> { item });
+        _kubernetesServiceMock.Setup(x => x.NamespaceExistsAsync("monitoring")).ReturnsAsync(true);
+        _kubernetesServiceMock.Setup(x => x.NamespaceExistsAsync("other")).ReturnsAsync(true);
+        _kubernetesServiceMock.Setup(x => x.GetExistingSecretNamesAsync(It.IsAny<string>())).ReturnsAsync(new List<string>());
+        _kubernetesServiceMock.Setup(x => x.GetManagedSecretNamesAsync(It.IsAny<string>())).ReturnsAsync(new List<string>());
+        _kubernetesServiceMock.Setup(x => x.SecretExistsAsync(It.IsAny<string>(), "netbird-setup")).ReturnsAsync(false);
+        _kubernetesServiceMock.Setup(x => x.GetSecretDataAsync(It.IsAny<string>(), "netbird-setup")).ReturnsAsync((Dictionary<string, string>?)null);
+        _kubernetesServiceMock.Setup(x => x.GetSecretAnnotationsAsync(It.IsAny<string>(), "netbird-setup")).ReturnsAsync((Dictionary<string, string>?)null);
+        _kubernetesServiceMock.Setup(x => x.GetSecretTypeAsync(It.IsAny<string>(), "netbird-setup")).ReturnsAsync((string?)null);
+        _kubernetesServiceMock.Setup(x => x.CreateSecretAsync(
+                It.IsAny<string>(), "netbird-setup", It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<string?>()))
+            .ReturnsAsync(OperationResult.Successful());
+        _kubernetesServiceMock.Setup(x => x.ApplyYamlAsync(It.IsAny<string>()))
+            .ReturnsAsync(OperationResult.Successful());
+
+        var result = await _syncService.SyncAsync();
+
+        result.OverallSuccess.Should().BeTrue();
+
+        // The Secret must be created with its YAML data in BOTH namespaces.
+        _kubernetesServiceMock.Verify(x => x.CreateSecretAsync(
+            "monitoring", "netbird-setup",
+            It.Is<Dictionary<string, string>>(d => d.ContainsKey("NETBIRD_SETUP_KEY") && d["NETBIRD_SETUP_KEY"] == "supersecretvalue"),
+            It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<string?>()),
+            Times.Once);
+        _kubernetesServiceMock.Verify(x => x.CreateSecretAsync(
+            "other", "netbird-setup",
+            It.Is<Dictionary<string, string>>(d => d.ContainsKey("NETBIRD_SETUP_KEY") && d["NETBIRD_SETUP_KEY"] == "supersecretvalue"),
+            It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<string?>()),
+            Times.Once);
+    }
+
     [Fact]
     public async Task SyncAsync_WithNoNamespacesAndNoYaml_ShouldNotApplyAnyYaml()
     {

--- a/VaultwardenK8sSync/Services/SyncService.cs
+++ b/VaultwardenK8sSync/Services/SyncService.cs
@@ -934,7 +934,10 @@ public class SyncService : ISyncService
                 // created an EMPTY secret (the normal path overwrote the YAML-applied one
                 // with no data, producing managed-keys: []). Now the YAML's stringData/data
                 // are carried through so the Secret has real content in every target namespace.
-                ExtractSecretDataFromNotesYaml(notesContent, data);
+                var targetSecretName = !string.IsNullOrEmpty(item.ExtractSecretName())
+                    ? SanitizeSecretName(item.ExtractSecretName()!)
+                    : SanitizeSecretName(item.Name ?? string.Empty);
+                ExtractSecretDataFromNotesYaml(notesContent, data, targetSecretName);
                 noteHandled = true;
             }
             else if (notesContent.TrimStart().StartsWith("stringData:", StringComparison.OrdinalIgnoreCase))
@@ -1333,8 +1336,11 @@ public class SyncService : ISyncService
     /// YAML manifest found in an item's notes. This lets the normal secret-sync path carry
     /// the YAML's values, so a YAML Secret combined with a `namespaces` custom field is
     /// created with real content instead of an empty secret.
+    /// To avoid merging unrelated manifests, only the V1Secret whose metadata.name matches
+    /// the target secret is considered. A single Secret in the YAML is always used (matching
+    /// the previous synchronized behavior); multiple definitions must have a unique match.
     /// </summary>
-    private static void ExtractSecretDataFromNotesYaml(string yaml, Dictionary<string, string> data)
+    private static void ExtractSecretDataFromNotesYaml(string yaml, Dictionary<string, string> data, string targetSecretName)
     {
         try
         {
@@ -1342,27 +1348,52 @@ public class SyncService : ISyncService
             if (objects == null)
                 return;
 
-            foreach (var obj in objects)
+            var secretDefs = objects.OfType<k8s.Models.V1Secret>().ToList();
+
+            k8s.Models.V1Secret? selected = null;
+            if (secretDefs.Count == 1)
             {
-                if (obj is not k8s.Models.V1Secret secret)
-                    continue;
-
-                if (secret.StringData != null)
+                // Single Secret definition: use it unconditionally (backwards compatible).
+                selected = secretDefs[0];
+            }
+            else if (secretDefs.Count > 1)
+            {
+                // Multiple Secret definitions: select the one whose name matches the target,
+                // and refuse ambiguous input (multiple matching) instead of merging them.
+                var matches = secretDefs
+                    .Where(s => string.Equals(s.Metadata?.Name, targetSecretName, StringComparison.Ordinal))
+                    .ToList();
+                if (matches.Count == 1)
                 {
-                    foreach (var kvp in secret.StringData)
-                    {
-                        if (!string.IsNullOrEmpty(kvp.Key) && !data.ContainsKey(kvp.Key) && kvp.Value != null)
-                            data[kvp.Key] = kvp.Value;
-                    }
+                    selected = matches[0];
                 }
-
-                if (secret.Data != null)
+                else if (matches.Count > 1)
                 {
-                    foreach (var kvp in secret.Data)
-                    {
-                        if (!string.IsNullOrEmpty(kvp.Key) && !data.ContainsKey(kvp.Key) && kvp.Value != null)
-                            data[kvp.Key] = System.Text.Encoding.UTF8.GetString(kvp.Value);
-                    }
+                    // Ambiguous: more than one definition targets this secret name. Skip
+                    // extraction rather than merging unrelated secrets.
+                    return;
+                }
+                // matches.Count == 0: no definition targets this secret, nothing to extract.
+            }
+
+            if (selected == null)
+                return;
+
+            if (selected.StringData != null)
+            {
+                foreach (var kvp in selected.StringData)
+                {
+                    if (!string.IsNullOrEmpty(kvp.Key) && !data.ContainsKey(kvp.Key) && kvp.Value != null)
+                        data[kvp.Key] = kvp.Value;
+                }
+            }
+
+            if (selected.Data != null)
+            {
+                foreach (var kvp in selected.Data)
+                {
+                    if (!string.IsNullOrEmpty(kvp.Key) && !data.ContainsKey(kvp.Key) && kvp.Value != null)
+                        data[kvp.Key] = System.Text.Encoding.UTF8.GetString(kvp.Value);
                 }
             }
         }

--- a/VaultwardenK8sSync/Services/SyncService.cs
+++ b/VaultwardenK8sSync/Services/SyncService.cs
@@ -929,6 +929,12 @@ public class SyncService : ISyncService
             if (IsKubernetesYaml(notesContent))
             {
                 yamlManifests?.Add(notesContent);
+                // If the YAML defines a Secret, extract its data into the secret dictionary.
+                // Without this, an item with YAML-in-notes + a `namespaces` custom field
+                // created an EMPTY secret (the normal path overwrote the YAML-applied one
+                // with no data, producing managed-keys: []). Now the YAML's stringData/data
+                // are carried through so the Secret has real content in every target namespace.
+                ExtractSecretDataFromNotesYaml(notesContent, data);
                 noteHandled = true;
             }
             else if (notesContent.TrimStart().StartsWith("stringData:", StringComparison.OrdinalIgnoreCase))
@@ -1319,6 +1325,51 @@ public class SyncService : ISyncService
         catch
         {
             return false;
+        }
+    }
+
+    /// <summary>
+    /// Best-effort extraction of a Secret's data (stringData and data) from a Kubernetes
+    /// YAML manifest found in an item's notes. This lets the normal secret-sync path carry
+    /// the YAML's values, so a YAML Secret combined with a `namespaces` custom field is
+    /// created with real content instead of an empty secret.
+    /// </summary>
+    private static void ExtractSecretDataFromNotesYaml(string yaml, Dictionary<string, string> data)
+    {
+        try
+        {
+            var objects = k8s.KubernetesYaml.LoadAllFromString(yaml);
+            if (objects == null)
+                return;
+
+            foreach (var obj in objects)
+            {
+                if (obj is not k8s.Models.V1Secret secret)
+                    continue;
+
+                if (secret.StringData != null)
+                {
+                    foreach (var kvp in secret.StringData)
+                    {
+                        if (!string.IsNullOrEmpty(kvp.Key) && !data.ContainsKey(kvp.Key) && kvp.Value != null)
+                            data[kvp.Key] = kvp.Value;
+                    }
+                }
+
+                if (secret.Data != null)
+                {
+                    foreach (var kvp in secret.Data)
+                    {
+                        if (!string.IsNullOrEmpty(kvp.Key) && !data.ContainsKey(kvp.Key) && kvp.Value != null)
+                            data[kvp.Key] = System.Text.Encoding.UTF8.GetString(kvp.Value);
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Extraction is best-effort; ApplyYamlAsync remains the authoritative application
+            // of the manifest itself.
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the case where a Vaultwarden item with a **Kubernetes Secret as YAML in its notes** plus a **`namespaces` custom field** produced an empty Secret.

### The bug
- `ApplyYamlAsync` applies the YAML manifest (creating the Secret with its `stringData`/`data`).
- But the normal secret-sync path (`SyncSecretAsync`) also processes the item, building `combinedSecretData` **only** from the item's credentials/custom fields — which is **empty** for a YAML-only item.
- The normal path then creates/overwrites the Secret with that empty data → `managed-keys: []`, no data. The YAML's content was clobbered.

Without the `namespaces` field (Path A, YAML-only items) only `ApplyYamlAsync` runs and the Secret stays intact — which is why "the YAML worked by itself, but broke once I added `namespaces`".

### The fix
Extract the Secret's `stringData`/`data` from the notes YAML into the secret's data dictionary (`ExtractSecretDataFromNotesYaml`). The normal secret-sync path now carries the YAML's values, so the Secret is created with real content **in every namespace** listed in the `namespaces` field.

**Code review refinement:** the helper now threads the resolved target secret name and selects **only the matching `V1Secret`** (`metadata.name`), so a note containing multiple Secret definitions no longer merges unrelated secrets into the target. A single Secret is still used unconditionally; ambiguous multi-match input is skipped.

## Tests
- `SyncAsync_YamlSecretInNotesWithNamespaces_ShouldCarryYamlData_NotEmpty` — YAML Secret + `namespaces` is created with the YAML's data, not empty.
- `SyncAsync_YamlSecretInNotesWithMultipleNamespaces_ShouldCreateWithDataInEach` — created with data in both declared namespaces.
- `SyncAsync_MultiSecretYamlInNotes_ShouldOnlyExtractMatchingSecret` — unrelated secrets don't bleed into the target.
- Local suite: **648 passed, 0 failed**.